### PR TITLE
Add masking for request and response body fields

### DIFF
--- a/src/Apitally/ApitallyOptions.cs
+++ b/src/Apitally/ApitallyOptions.cs
@@ -32,6 +32,7 @@ public class RequestLoggingOptions
     public bool IncludeException { get; set; } = true;
     public List<string> QueryParamMaskPatterns { get; set; } = [];
     public List<string> HeaderMaskPatterns { get; set; } = [];
+    public List<string> BodyFieldMaskPatterns { get; set; } = [];
     public List<string> PathExcludePatterns { get; set; } = [];
 
     /// <summary>

--- a/src/Apitally/RequestLogger.cs
+++ b/src/Apitally/RequestLogger.cs
@@ -473,7 +473,7 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
     {
         var contentType = GetHeaderValue(headers, "content-type");
         return contentType != null
-            && contentType.Contains("json", StringComparison.OrdinalIgnoreCase);
+            && Regex.IsMatch(contentType, @"\bjson\b", RegexOptions.IgnoreCase);
     }
 
     private static string? GetHeaderValue(Header[] headers, string name)

--- a/src/Apitally/RequestLogger.cs
+++ b/src/Apitally/RequestLogger.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Apitally.Models;
 using Microsoft.Extensions.Hosting;
@@ -55,6 +56,17 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
         "token",
         "cookie",
     ];
+    private static readonly string[] MaskBodyFieldPatterns =
+    [
+        "password",
+        "pwd",
+        "token",
+        "secret",
+        "auth",
+        "card[-_ ]?number",
+        "ccv",
+        "ssn",
+    ];
 
     public static readonly string[] AllowedContentTypes =
     [
@@ -63,7 +75,7 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
     ];
 
     private readonly object _lock = new();
-    private readonly ConcurrentQueue<string> _pendingWrites = new();
+    private readonly ConcurrentQueue<RequestLogItem> _pendingWrites = new();
     private readonly ConcurrentQueue<TempGzipFile> _files = new();
     private readonly List<Regex> _compiledPathExcludePatterns = CompilePatterns(
         ExcludePathPatterns,
@@ -80,6 +92,10 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
     private readonly List<Regex> _compiledHeaderMaskPatterns = CompilePatterns(
         MaskHeaderPatterns,
         options.Value.RequestLogging.HeaderMaskPatterns
+    );
+    private readonly List<Regex> _compiledBodyFieldMaskPatterns = CompilePatterns(
+        MaskBodyFieldPatterns,
+        options.Value.RequestLogging.BodyFieldMaskPatterns
     );
     private readonly JsonSerializerOptions _serializerOptions = new()
     {
@@ -129,24 +145,6 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
                 return;
             }
 
-            // Process query params and URL
-            if (!string.IsNullOrEmpty(request.Url))
-            {
-                var uri = new Uri(request.Url);
-                var query = uri.Query.TrimStart('?');
-                if (!requestLoggingOptions.IncludeQueryParams)
-                {
-                    query = string.Empty;
-                }
-                else if (!string.IsNullOrEmpty(query))
-                {
-                    query = MaskQueryParams(query);
-                }
-                var uriBuilder = new UriBuilder(uri) { Query = query };
-                request.Url = uriBuilder.Uri.ToString();
-            }
-
-            // Process request body
             if (
                 !requestLoggingOptions.IncludeRequestBody
                 || !HasSupportedContentType(request.Headers)
@@ -154,23 +152,6 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
             {
                 request.Body = null;
             }
-            else if (request.Body != null)
-            {
-                if (request.Body.Length > MaxBodySize)
-                {
-                    request.Body = BodyTooLarge;
-                }
-                else
-                {
-                    request.Body = requestLoggingOptions.MaskRequestBody(request) ?? BodyMasked;
-                    if (request.Body.Length > MaxBodySize)
-                    {
-                        request.Body = BodyTooLarge;
-                    }
-                }
-            }
-
-            // Process response body
             if (
                 !requestLoggingOptions.IncludeResponseBody
                 || !HasSupportedContentType(response.Headers)
@@ -178,32 +159,7 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
             {
                 response.Body = null;
             }
-            else if (response.Body != null)
-            {
-                if (response.Body.Length > MaxBodySize)
-                {
-                    response.Body = BodyTooLarge;
-                }
-                else
-                {
-                    response.Body =
-                        requestLoggingOptions.MaskResponseBody(request, response) ?? BodyMasked;
-                    if (response.Body.Length > MaxBodySize)
-                    {
-                        response.Body = BodyTooLarge;
-                    }
-                }
-            }
 
-            // Process headers
-            request.Headers = requestLoggingOptions.IncludeRequestHeaders
-                ? MaskHeaders(request.Headers)
-                : [];
-            response.Headers = requestLoggingOptions.IncludeResponseHeaders
-                ? MaskHeaders(response.Headers)
-                : [];
-
-            // Create exception info
             var exceptionInfo =
                 exception != null && requestLoggingOptions.IncludeException
                     ? new ExceptionInfo
@@ -216,15 +172,14 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
                     }
                     : null;
 
-            // Create log item
+            // Create log item and enqueue
             var item = new RequestLogItem
             {
                 Request = request,
                 Response = response,
                 Exception = exceptionInfo,
             };
-            var serializedItem = JsonSerializer.Serialize(item, _serializerOptions);
-            _pendingWrites.Enqueue(serializedItem);
+            _pendingWrites.Enqueue(item);
 
             if (_pendingWrites.Count > MaxPendingWrites)
             {
@@ -249,7 +204,9 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
             _currentFile ??= new TempGzipFile();
             while (_pendingWrites.TryDequeue(out var item))
             {
-                _currentFile.WriteLine(Encoding.UTF8.GetBytes(item));
+                ApplyMasking(item);
+                var serializedItem = JsonSerializer.Serialize(item, _serializerOptions);
+                _currentFile.WriteLine(Encoding.UTF8.GetBytes(serializedItem));
             }
         }
     }
@@ -315,6 +272,80 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
         }
     }
 
+    private void ApplyMasking(RequestLogItem item)
+    {
+        var requestLoggingOptions = options.Value.RequestLogging;
+        var request = item.Request;
+        var response = item.Response;
+
+        if (request.Body != null)
+        {
+            // Apply user-provided masking callback for request body
+            request.Body = requestLoggingOptions.MaskRequestBody(request) ?? BodyMasked;
+
+            if (request.Body.Length > MaxBodySize)
+            {
+                request.Body = BodyTooLarge;
+            }
+
+            // Mask request body fields (if JSON)
+            if (
+                !request.Body.SequenceEqual(BodyTooLarge)
+                && !request.Body.SequenceEqual(BodyMasked)
+                && RequestLogger.HasJsonContentType(request.Headers)
+            )
+            {
+                request.Body = MaskJsonBody(request.Body);
+            }
+        }
+
+        if (response.Body != null)
+        {
+            // Apply user-provided masking callback for response body
+            response.Body = requestLoggingOptions.MaskResponseBody(request, response) ?? BodyMasked;
+
+            if (response.Body.Length > MaxBodySize)
+            {
+                response.Body = BodyTooLarge;
+            }
+
+            // Mask response body fields (if JSON)
+            if (
+                !response.Body.SequenceEqual(BodyTooLarge)
+                && !response.Body.SequenceEqual(BodyMasked)
+                && RequestLogger.HasJsonContentType(response.Headers)
+            )
+            {
+                response.Body = MaskJsonBody(response.Body);
+            }
+        }
+
+        // Mask headers
+        request.Headers = requestLoggingOptions.IncludeRequestHeaders
+            ? MaskHeaders(request.Headers)
+            : [];
+        response.Headers = requestLoggingOptions.IncludeResponseHeaders
+            ? MaskHeaders(response.Headers)
+            : [];
+
+        // Mask query params
+        if (!string.IsNullOrEmpty(request.Url))
+        {
+            var uri = new Uri(request.Url);
+            var query = uri.Query.TrimStart('?');
+            if (!requestLoggingOptions.IncludeQueryParams)
+            {
+                query = string.Empty;
+            }
+            else if (!string.IsNullOrEmpty(query))
+            {
+                query = MaskQueryParams(query);
+            }
+            var uriBuilder = new UriBuilder(uri) { Query = query };
+            request.Url = uriBuilder.Uri.ToString();
+        }
+    }
+
     private bool ShouldExcludePath(string? path)
     {
         return !string.IsNullOrEmpty(path)
@@ -335,6 +366,69 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
     private bool ShouldMaskHeader(string name)
     {
         return _compiledHeaderMaskPatterns.Any(p => p.IsMatch(name));
+    }
+
+    private bool ShouldMaskBodyField(string name)
+    {
+        return _compiledBodyFieldMaskPatterns.Any(p => p.IsMatch(name));
+    }
+
+    private byte[] MaskJsonBody(byte[] body)
+    {
+        try
+        {
+            var json = Encoding.UTF8.GetString(body);
+            var node = JsonNode.Parse(json);
+            if (node != null)
+            {
+                MaskJsonNode(node);
+                return Encoding.UTF8.GetBytes(node.ToJsonString(_serializerOptions));
+            }
+            return body;
+        }
+        catch
+        {
+            return body;
+        }
+    }
+
+    private void MaskJsonNode(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject jsonObject:
+                var propertiesToMask = new List<string>();
+                foreach (var property in jsonObject)
+                {
+                    if (
+                        property.Value is JsonValue jsonValue
+                        && jsonValue.TryGetValue<string>(out _)
+                        && ShouldMaskBodyField(property.Key)
+                    )
+                    {
+                        propertiesToMask.Add(property.Key);
+                    }
+                    else if (property.Value != null)
+                    {
+                        MaskJsonNode(property.Value);
+                    }
+                }
+                foreach (var propertyKey in propertiesToMask)
+                {
+                    jsonObject[propertyKey] = JsonValue.Create(Masked);
+                }
+                break;
+
+            case JsonArray jsonArray:
+                foreach (var item in jsonArray)
+                {
+                    if (item != null)
+                    {
+                        MaskJsonNode(item);
+                    }
+                }
+                break;
+        }
     }
 
     private string MaskQueryParams(string query)
@@ -373,6 +467,13 @@ class RequestLogger(IOptions<ApitallyOptions> options, ILogger<RequestLogger> lo
             && AllowedContentTypes.Any(ct =>
                 contentType.StartsWith(ct, StringComparison.OrdinalIgnoreCase)
             );
+    }
+
+    private static bool HasJsonContentType(Header[] headers)
+    {
+        var contentType = GetHeaderValue(headers, "content-type");
+        return contentType != null
+            && contentType.Contains("json", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? GetHeaderValue(Header[] headers, string name)

--- a/tests/Apitally.Tests/RequestLoggerTests.cs
+++ b/tests/Apitally.Tests/RequestLoggerTests.cs
@@ -46,51 +46,45 @@ public class RequestLoggerTests
 
         // Act
         requestLogger.LogRequest(request, response, new Exception("test"));
-        requestLogger.Maintain();
-        requestLogger.RotateFile();
 
         // Assert
-        var logFile = requestLogger.GetFile();
-        Assert.NotNull(logFile);
-        Assert.True(logFile.Size > 0);
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
 
-        var lines = logFile.ReadDecompressedLines();
-        Assert.Single(lines);
-
-        var jsonNode = JsonDocument.Parse(lines[0]).RootElement;
-        Assert.Equal("GET", jsonNode.GetProperty("request").GetProperty("method").GetString());
-        Assert.Equal("/items", jsonNode.GetProperty("request").GetProperty("path").GetString());
+        var item = items[0];
+        Assert.Equal("GET", item.GetProperty("request").GetProperty("method").GetString());
+        Assert.Equal("/items", item.GetProperty("request").GetProperty("path").GetString());
         Assert.Equal(
             "http://test/items",
-            jsonNode.GetProperty("request").GetProperty("url").GetString()
+            item.GetProperty("request").GetProperty("url").GetString()
         );
-        Assert.False(jsonNode.GetProperty("request").TryGetProperty("body", out _));
-        Assert.Equal(200, jsonNode.GetProperty("response").GetProperty("status_code").GetInt32());
+        Assert.False(item.GetProperty("request").TryGetProperty("body", out _));
+        Assert.Equal(200, item.GetProperty("response").GetProperty("status_code").GetInt32());
         Assert.Equal(
             0.123,
-            jsonNode.GetProperty("response").GetProperty("response_time").GetDouble(),
+            item.GetProperty("response").GetProperty("response_time").GetDouble(),
             3
         );
         Assert.Equal(
-            "{\"items\": []}",
+            "{\"items\":[]}",
             Encoding.UTF8.GetString(
                 Convert.FromBase64String(
-                    jsonNode.GetProperty("response").GetProperty("body").GetString()!
+                    item.GetProperty("response").GetProperty("body").GetString()!
                 )
             )
         );
 
-        var requestHeadersNode = jsonNode.GetProperty("request").GetProperty("headers");
+        var requestHeadersNode = item.GetProperty("request").GetProperty("headers");
         Assert.Equal(1, requestHeadersNode.GetArrayLength());
         Assert.Equal("User-Agent", requestHeadersNode[0][0].GetString());
         Assert.Equal("Test", requestHeadersNode[0][1].GetString());
 
-        var responseHeadersNode = jsonNode.GetProperty("response").GetProperty("headers");
+        var responseHeadersNode = item.GetProperty("response").GetProperty("headers");
         Assert.Equal(1, responseHeadersNode.GetArrayLength());
         Assert.Equal("Content-Type", responseHeadersNode[0][0].GetString());
         Assert.Equal("application/json", responseHeadersNode[0][1].GetString());
 
-        var exceptionNode = jsonNode.GetProperty("exception");
+        var exceptionNode = item.GetProperty("exception");
         Assert.Equal("Exception", exceptionNode.GetProperty("type").GetString());
         Assert.Equal("test", exceptionNode.GetProperty("message").GetString());
 
@@ -139,26 +133,20 @@ public class RequestLoggerTests
 
         // Act
         requestLogger.LogRequest(request, response);
-        requestLogger.Maintain();
-        requestLogger.RotateFile();
 
         // Assert
-        var logFile = requestLogger.GetFile();
-        Assert.NotNull(logFile);
-        Assert.True(logFile.Size > 0);
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
 
-        var lines = logFile.ReadDecompressedLines();
-        Assert.Single(lines);
-
-        var jsonNode = JsonDocument.Parse(lines[0]).RootElement;
+        var item = items[0];
         Assert.Equal(
             "http://test/items",
-            jsonNode.GetProperty("request").GetProperty("url").GetString()
+            item.GetProperty("request").GetProperty("url").GetString()
         );
-        Assert.Empty(jsonNode.GetProperty("request").GetProperty("headers").EnumerateArray());
-        Assert.False(jsonNode.GetProperty("request").TryGetProperty("body", out _));
-        Assert.Empty(jsonNode.GetProperty("response").GetProperty("headers").EnumerateArray());
-        Assert.False(jsonNode.GetProperty("response").TryGetProperty("body", out _));
+        Assert.Empty(item.GetProperty("request").GetProperty("headers").EnumerateArray());
+        Assert.False(item.GetProperty("request").TryGetProperty("body", out _));
+        Assert.Empty(item.GetProperty("response").GetProperty("headers").EnumerateArray());
+        Assert.False(item.GetProperty("response").TryGetProperty("body", out _));
     }
 
     [Fact]
@@ -197,10 +185,8 @@ public class RequestLoggerTests
         requestLogger.LogRequest(request, response);
 
         // Assert
-        requestLogger.Maintain();
-        requestLogger.RotateFile();
-        var logFile = requestLogger.GetFile();
-        Assert.Null(logFile);
+        var items = GetLoggedItems(requestLogger);
+        Assert.Empty(items);
     }
 
     [Fact]
@@ -231,10 +217,8 @@ public class RequestLoggerTests
         requestLogger.LogRequest(request, response);
 
         // Assert
-        requestLogger.Maintain();
-        requestLogger.RotateFile();
-        var logFile = requestLogger.GetFile();
-        Assert.Null(logFile);
+        var items = GetLoggedItems(requestLogger);
+        Assert.Empty(items);
     }
 
     [Fact]
@@ -265,14 +249,59 @@ public class RequestLoggerTests
         requestLogger.LogRequest(request, response);
 
         // Assert
-        requestLogger.Maintain();
-        requestLogger.RotateFile();
-        var logFile = requestLogger.GetFile();
-        Assert.Null(logFile);
+        var items = GetLoggedItems(requestLogger);
+        Assert.Empty(items);
     }
 
     [Fact]
-    public void LogRequest_ShouldMask()
+    public void LogRequest_ShouldMaskHeaders()
+    {
+        // Arrange
+        var requestLogger = CreateRequestLogger(
+            new RequestLoggingOptions
+            {
+                Enabled = true,
+                IncludeRequestHeaders = true,
+                HeaderMaskPatterns = new List<string> { "(?i)test" },
+            }
+        );
+        var request = new Request
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Method = "GET",
+            Path = "/test",
+            Url = "http://localhost:8000/test?foo=bar",
+            Headers = new[]
+            {
+                new Header("Accept", "text/plain"),
+                new Header("Authorization", "Bearer 123456"),
+                new Header("X-Test", "123456"),
+            },
+            Body = Array.Empty<byte>(),
+        };
+        var response = new Response { StatusCode = 200 };
+
+        // Act
+        requestLogger.LogRequest(request, response);
+
+        // Assert
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
+        var requestHeaders = items[0].GetProperty("request").GetProperty("headers");
+
+        var headers = new Dictionary<string, string>();
+        foreach (var header in requestHeaders.EnumerateArray())
+        {
+            headers.Add(header[0].GetString()!, header[1].GetString()!);
+        }
+
+        Assert.Equal("text/plain", headers["Accept"]);
+        Assert.Equal("******", headers["Authorization"]);
+        Assert.Equal("******", headers["X-Test"]);
+    }
+
+    [Fact]
+    public void LogRequest_ShouldMaskQueryParams()
     {
         // Arrange
         var requestLogger = CreateRequestLogger(
@@ -280,77 +309,191 @@ public class RequestLoggerTests
             {
                 Enabled = true,
                 IncludeQueryParams = true,
-                IncludeRequestHeaders = true,
-                IncludeRequestBody = true,
-                IncludeResponseHeaders = true,
-                IncludeResponseBody = true,
-                MaskRequestBody = request => null,
-                MaskResponseBody = (request, response) => null,
+                QueryParamMaskPatterns = new List<string> { "(?i)test" },
             }
         );
         var request = new Request
         {
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            Consumer = "tester",
-            Method = "POST",
-            Path = "/items",
-            Url = "http://test/items?token=my-secret-token",
-            Headers = new[]
+            Method = "GET",
+            Path = "/test",
+            Url = "http://localhost/test?secret=123456&test=123456&other=abcdef",
+            Headers = Array.Empty<Header>(),
+            Body = Array.Empty<byte>(),
+        };
+        var response = new Response { StatusCode = 200 };
+
+        // Act
+        requestLogger.LogRequest(request, response);
+
+        // Assert
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
+        var url = items[0].GetProperty("request").GetProperty("url").GetString();
+        Assert.Contains("secret=******", url);
+        Assert.Contains("test=******", url);
+        Assert.Contains("other=abcdef", url);
+    }
+
+    [Fact]
+    public void LogRequest_ShouldMaskBodyUsingCallback()
+    {
+        // Arrange
+        var requestLogger = CreateRequestLogger(
+            new RequestLoggingOptions
             {
-                new Header("Authorization", "Bearer 1234567890"),
-                new Header("Content-Type", "application/json"),
-            },
-            Size = 16,
-            Body = Encoding.UTF8.GetBytes("{\"key\": \"value\"}"),
+                Enabled = true,
+                IncludeRequestBody = true,
+                IncludeResponseBody = true,
+                MaskRequestBody = (req) =>
+                {
+                    if (req.Path == "/test")
+                        return null;
+                    return req.Body;
+                },
+                MaskResponseBody = (req, resp) =>
+                {
+                    if (req.Path == "/test")
+                        return null;
+                    return resp.Body;
+                },
+            }
+        );
+        var request = new Request
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Method = "GET",
+            Path = "/test",
+            Headers = new[] { new Header("Content-Type", "application/json") },
+            Body = Encoding.UTF8.GetBytes("test"),
         };
         var response = new Response
         {
             StatusCode = 200,
-            ResponseTime = 0.123,
             Headers = new[] { new Header("Content-Type", "application/json") },
-            Size = 16,
-            Body = Encoding.UTF8.GetBytes("{\"key\": \"value\"}"),
+            Body = Encoding.UTF8.GetBytes("test"),
         };
 
         // Act
         requestLogger.LogRequest(request, response);
+
+        // Assert
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
+        var requestBody = Encoding.UTF8.GetString(
+            Convert.FromBase64String(
+                items[0].GetProperty("request").GetProperty("body").GetString()!
+            )
+        );
+        Assert.Equal("<masked>", requestBody);
+
+        var responseBody = Encoding.UTF8.GetString(
+            Convert.FromBase64String(
+                items[0].GetProperty("response").GetProperty("body").GetString()!
+            )
+        );
+        Assert.Equal("<masked>", responseBody);
+    }
+
+    [Fact]
+    public void LogRequest_ShouldMaskBodyFields()
+    {
+        // Arrange
+        var requestLogger = CreateRequestLogger(
+            new RequestLoggingOptions
+            {
+                Enabled = true,
+                IncludeRequestBody = true,
+                IncludeResponseBody = true,
+                BodyFieldMaskPatterns = new List<string> { "(?i)custom" },
+            }
+        );
+
+        var requestBodyJson =
+            @"{""username"":""john_doe"",""password"":""secret123"",""token"":""abc123"",""custom"":""xyz789"",""user_id"":42,""api_key"":123,""normal_field"":""value"",""nested"":{""password"":""nested_secret"",""count"":5,""deeper"":{""auth"":""deep_token""}},""array"":[{""password"":""array_secret"",""id"":1},{""normal"":""text"",""token"":""array_token""}]}";
+        var responseBodyJson =
+            @"{""status"":""success"",""secret"":""response_secret"",""data"":{""pwd"":""response_pwd""}}";
+
+        var request = new Request
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Method = "POST",
+            Path = "/test",
+            Url = "http://localhost:8000/test?foo=bar",
+            Headers = new[] { new Header("Content-Type", "application/json") },
+            Body = Encoding.UTF8.GetBytes(requestBodyJson),
+        };
+        var response = new Response
+        {
+            StatusCode = 200,
+            ResponseTime = 0.1,
+            Headers = new[] { new Header("Content-Type", "application/json") },
+            Body = Encoding.UTF8.GetBytes(responseBodyJson),
+        };
+
+        // Act
+        requestLogger.LogRequest(request, response);
+
+        // Assert
+        var items = GetLoggedItems(requestLogger);
+        Assert.Single(items);
+
+        var reqBodyBase64 = items[0].GetProperty("request").GetProperty("body").GetString();
+        var reqBody = JsonDocument
+            .Parse(Encoding.UTF8.GetString(Convert.FromBase64String(reqBodyBase64!)))
+            .RootElement;
+
+        var respBodyBase64 = items[0].GetProperty("response").GetProperty("body").GetString();
+        var respBody = JsonDocument
+            .Parse(Encoding.UTF8.GetString(Convert.FromBase64String(respBodyBase64!)))
+            .RootElement;
+
+        // Test fields that should be masked
+        Assert.Equal("******", reqBody.GetProperty("password").GetString());
+        Assert.Equal("******", reqBody.GetProperty("token").GetString());
+        Assert.Equal("******", reqBody.GetProperty("custom").GetString());
+        Assert.Equal("******", reqBody.GetProperty("nested").GetProperty("password").GetString());
+        Assert.Equal(
+            "******",
+            reqBody.GetProperty("nested").GetProperty("deeper").GetProperty("auth").GetString()
+        );
+        Assert.Equal("******", reqBody.GetProperty("array")[0].GetProperty("password").GetString());
+        Assert.Equal("******", reqBody.GetProperty("array")[1].GetProperty("token").GetString());
+        Assert.Equal("******", respBody.GetProperty("secret").GetString());
+        Assert.Equal("******", respBody.GetProperty("data").GetProperty("pwd").GetString());
+
+        // Test fields that should NOT be masked
+        Assert.Equal("john_doe", reqBody.GetProperty("username").GetString());
+        Assert.Equal(42, reqBody.GetProperty("user_id").GetInt32());
+        Assert.Equal(123, reqBody.GetProperty("api_key").GetInt32());
+        Assert.Equal("value", reqBody.GetProperty("normal_field").GetString());
+        Assert.Equal(5, reqBody.GetProperty("nested").GetProperty("count").GetInt32());
+        Assert.Equal(1, reqBody.GetProperty("array")[0].GetProperty("id").GetInt32());
+        Assert.Equal("text", reqBody.GetProperty("array")[1].GetProperty("normal").GetString());
+        Assert.Equal("success", respBody.GetProperty("status").GetString());
+    }
+
+    private static JsonElement[] GetLoggedItems(RequestLogger requestLogger)
+    {
         requestLogger.Maintain();
         requestLogger.RotateFile();
 
-        // Assert
         var logFile = requestLogger.GetFile();
-        Assert.NotNull(logFile);
-        Assert.True(logFile.Size > 0);
+        if (logFile == null)
+        {
+            return Array.Empty<JsonElement>();
+        }
 
         var lines = logFile.ReadDecompressedLines();
-        Assert.Single(lines);
+        var items = new JsonElement[lines.Count];
 
-        var jsonNode = JsonDocument.Parse(lines[0]).RootElement;
-        Assert.Equal(
-            "http://test/items?token=******",
-            jsonNode.GetProperty("request").GetProperty("url").GetString()
-        );
-        Assert.Equal(
-            "<masked>",
-            Encoding.UTF8.GetString(
-                Convert.FromBase64String(
-                    jsonNode.GetProperty("request").GetProperty("body").GetString()!
-                )
-            )
-        );
-        Assert.Equal(
-            "<masked>",
-            Encoding.UTF8.GetString(
-                Convert.FromBase64String(
-                    jsonNode.GetProperty("response").GetProperty("body").GetString()!
-                )
-            )
-        );
+        for (int i = 0; i < lines.Count; i++)
+        {
+            items[i] = JsonDocument.Parse(lines[i]).RootElement;
+        }
 
-        var requestHeadersNode = jsonNode.GetProperty("request").GetProperty("headers");
-        Assert.Equal(2, requestHeadersNode.GetArrayLength());
-        Assert.Equal("Authorization", requestHeadersNode[0][0].GetString());
-        Assert.Equal("******", requestHeadersNode[0][1].GetString());
+        logFile.Delete();
+        return items;
     }
 
     private static RequestLogger CreateRequestLogger(RequestLoggingOptions requestLoggingOptions)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for masking specific fields in JSON request and response bodies during logging, enhancing privacy for sensitive data.

- **Bug Fixes**
  - Improved consistency and reliability of masking for headers, query parameters, and body fields in logs.

- **Tests**
  - Introduced new tests to verify masking of headers, query parameters, and JSON body fields.
  - Refactored test methods for clearer and more robust validation of log masking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->