### PR TITLE
Stop force-registering MVC services in AddApitally

### DIFF
--- a/src/Apitally/ApitallyExtensions.cs
+++ b/src/Apitally/ApitallyExtensions.cs
@@ -58,7 +58,9 @@ public static class ApitallyExtensions
         // Inert unless the user calls AddControllers() — keeps minimal-API apps free of MVC services.
         services.Configure<MvcOptions>(options =>
         {
-            options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
+            var filter = (TypeFilterAttribute)
+                options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
+            filter.IsReusable = true;
         });
 
         // Register RequestLogger and ApitallyClient

--- a/src/Apitally/ApitallyExtensions.cs
+++ b/src/Apitally/ApitallyExtensions.cs
@@ -1,6 +1,7 @@
 namespace Apitally;
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,14 +55,10 @@ public static class ApitallyExtensions
             sp.GetRequiredService<ApitallyLoggerProvider>()
         );
 
-        // Ensure MVC services are registered and add global filter
-        services.AddSingleton<ValidationErrorFilter>();
-        services.AddControllers(options =>
+        // Inert unless the user calls AddControllers() — keeps minimal-API apps free of MVC services.
+        services.Configure<MvcOptions>(options =>
         {
-            var filter = services
-                .BuildServiceProvider()
-                .GetRequiredService<ValidationErrorFilter>();
-            options.Filters.Add(filter);
+            options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
         });
 
         // Register RequestLogger and ApitallyClient

--- a/src/Apitally/ValidationErrorFilter.cs
+++ b/src/Apitally/ValidationErrorFilter.cs
@@ -3,11 +3,10 @@ namespace Apitally;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 
-public class ValidationErrorFilter(ILogger<ValidationErrorFilter> logger)
-    : IActionFilter,
-        IOrderedFilter
+public class ValidationErrorFilter(ILogger<ValidationErrorFilter> logger) : IActionFilter
 {
-    public int Order => int.MinValue + 100;
+    // Must run before MVC's ModelStateInvalidFilter (Order = -2000), which short-circuits with a 400.
+    public const int FilterOrder = int.MinValue + 100;
 
     public void OnActionExecuting(ActionExecutingContext context)
     {

--- a/tests/Apitally.TestApp/ApitallyTestExtensions.cs
+++ b/tests/Apitally.TestApp/ApitallyTestExtensions.cs
@@ -32,7 +32,9 @@ public static class ApitallyTestExtensions
 
         services.Configure<MvcOptions>(options =>
         {
-            options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
+            var filter = (TypeFilterAttribute)
+                options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
+            filter.IsReusable = true;
         });
         services.AddSingleton<RequestLogger>();
         services.AddSingleton<ApitallyClient>();

--- a/tests/Apitally.TestApp/ApitallyTestExtensions.cs
+++ b/tests/Apitally.TestApp/ApitallyTestExtensions.cs
@@ -1,6 +1,7 @@
 namespace Apitally.TestApp;
 
 using Apitally;
+using Microsoft.AspNetCore.Mvc;
 
 public static class ApitallyTestExtensions
 {
@@ -29,13 +30,9 @@ public static class ApitallyTestExtensions
             sp.GetRequiredService<ApitallyLoggerProvider>()
         );
 
-        services.AddSingleton<ValidationErrorFilter>();
-        services.AddControllers(options =>
+        services.Configure<MvcOptions>(options =>
         {
-            var filter = services
-                .BuildServiceProvider()
-                .GetRequiredService<ValidationErrorFilter>();
-            options.Filters.Add(filter);
+            options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder);
         });
         services.AddSingleton<RequestLogger>();
         services.AddSingleton<ApitallyClient>();


### PR DESCRIPTION
## Summary
- `AddApitally()` no longer calls `services.AddControllers(...)`. Apps using only minimal APIs no longer get the entire MVC services graph (model binders, formatters, action descriptor providers, controller activator, filter pipeline, application part manager) injected into DI.
- The validation error filter is now registered via `services.Configure<MvcOptions>(...)`, which is inert unless the user opts into MVC themselves via `AddControllers()`. When they do, the filter still attaches automatically.
- Removes the `services.BuildServiceProvider()` mid-registration anti-pattern (analyzer `ASP0000`).

## Behavior
- **MVC users** — unchanged. `ValidationErrorFilter` still runs ahead of `ModelStateInvalidFilter` (explicit `Order = int.MinValue + 100` is now applied at the add site, since `TypeFilterAttribute` doesn't propagate the inner filter's `IOrderedFilter.Order`).
- **Minimal-API-only users** — leaner DI graph, faster startup, no MVC services pulled in.

The public README setup snippet doesn't currently mention `AddControllers`, so this is not a documented behavior change.

Resolves [DEV-132](https://linear.app/apitally/issue/DEV-132/stop-force-registering-mvc-services-in-addapitally).

## Test plan
- [x] `dotnet build` succeeds across `net6.0;net7.0;net8.0;net9.0`
- [x] `dotnet test` — full suite (57 tests) passes on net8.0 and net9.0; net6.0/net7.0 pre-existing limitation from `xunit.runner.visualstudio`
- [x] `ValidationErrorCounter_ShouldCountErrors` integration test still captures validation errors via the MVC controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove forced MVC registration from `AddApitally()` to keep minimal API apps lean while preserving behavior for MVC users. Also mark `ValidationErrorFilter` reusable to cut per-request allocations. Resolves DEV-132.

- **Refactors**
  - Replaced `services.AddControllers(...)` with `services.Configure<MvcOptions>(...)` to add `ValidationErrorFilter` only when the app opts into MVC.
  - Removed mid-registration `services.BuildServiceProvider()` usage.
  - Set explicit filter order via `options.Filters.Add<ValidationErrorFilter>(ValidationErrorFilter.FilterOrder)` to run before `ModelStateInvalidFilter`.
  - Marked the `TypeFilter` as reusable (`filter.IsReusable = true`) since `ValidationErrorFilter` is stateless.

<sup>Written for commit 685bcfa66dee7e2e5508dbdacaf82502e9ecbe82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

